### PR TITLE
Update slash-command.mdx

### DIFF
--- a/apps/docs/guides/tailwind/slash-command.mdx
+++ b/apps/docs/guides/tailwind/slash-command.mdx
@@ -172,6 +172,7 @@ Components are wrapper over cmdk
 <EditorContent>
   <EditorCommand className='z-50 h-auto max-h-[330px]  w-72 overflow-y-auto rounded-md border border-muted bg-background px-1 py-2 shadow-md transition-all'>
     <EditorCommandEmpty className='px-2 text-muted-foreground'>No results</EditorCommandEmpty>
+<EditorCommandList>
     {suggestionItems.map((item) => (
       <EditorCommandItem
         value={item.title}
@@ -187,6 +188,7 @@ Components are wrapper over cmdk
         </div>
       </EditorCommandItem>
     ))}
+</EditorCommandList>
   </EditorCommand>
 </EditorContent>
 ...


### PR DESCRIPTION
## Summary

This pull request fixes an issue where `suggestionItems` were not wrapped with the `<EditorCommandList>` component, which is necessary for proper functionality.

## Changes

- Wrapped `suggestionItems` with `<EditorCommandList>`.

## Reason for Changes

The `suggestionItems` need to be wrapped with `<EditorCommandList>` to ensure they function correctly. Without this wrapper, the suggestions may not display or behave as intended.

## Testing

- Verified that `suggestionItems` are now properly wrapped and functioning as expected.
- Ran existing tests to ensure no regressions were introduced.

## Related Issues

- If applicable, reference any related issues or pull requests.

Please review the changes and let me know if there are any further adjustments needed.
